### PR TITLE
travis-ci test only ruby-2.1.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ bundler_args: "--without development --path=~/.bundle"
 language: ruby
 rvm:
 - 2.1.2
-- 2.0.0
 env:
   matrix:
   - DB_TEST_DATABASE=rendezvous_test DB_TEST_USER=travis


### PR DESCRIPTION
travis-ciのテスト対象をruby-2.1.2のみに変更
